### PR TITLE
Allow for customization of placeholder attributes.

### DIFF
--- a/Example/JJMaterialTextField/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/JJMaterialTextField/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -48,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/Example/JJMaterialTextField/JJViewController.m
+++ b/Example/JJMaterialTextField/JJViewController.m
@@ -9,7 +9,7 @@
 #import "JJViewController.h"
 
 @interface JJViewController ()
-
+@property (nonatomic, strong) JJMaterialTextfield *passwordTextField;
 @end
 
 @implementation JJViewController
@@ -51,10 +51,15 @@
     [button setTitle:@"Submit" forState:UIControlStateNormal];
     [button setBackgroundColor:[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000]];
     [self.view addSubview:button];
-    
-    
-	// Do any additional setup after loading the view, typically from a nib.
+    [button addTarget:self action:@selector(submit) forControlEvents:UIControlEventTouchUpInside];
+
 }
+
+- (void)submit
+{
+    [self.passwordTextField showError];
+}
+
 
 -(void)textFieldDidEndEditing:(JJMaterialTextfield *)textField{
     if (textField.text.length==0) {

--- a/Example/JJMaterialTextField/JJViewController.m
+++ b/Example/JJMaterialTextField/JJViewController.m
@@ -45,6 +45,11 @@
     passTextField.secureTextEntry=YES;
     passTextField.returnKeyType=UIReturnKeyDone;
     passTextField.tag=2;
+    passTextField.font = [UIFont systemFontOfSize:15];
+    passTextField.textColor = [UIColor whiteColor];
+    passTextField.placeholderAttributes = @{NSFontAttributeName : [UIFont systemFontOfSize:20],
+                                            NSForegroundColorAttributeName : [[UIColor grayColor] colorWithAlphaComponent:.8]};
+//    passTextField.placeholderFontSize = 20;
     [self.view addSubview:passTextField];
     
     UIButton *button=[[UIButton alloc] initWithFrame:CGRectMake(40, 300, self.view.frame.size.width-80, 60)];

--- a/Example/JJMaterialTextField/JJViewController.m
+++ b/Example/JJMaterialTextField/JJViewController.m
@@ -9,7 +9,7 @@
 #import "JJViewController.h"
 
 @interface JJViewController ()
-
+@property (nonatomic, strong) JJMaterialTextfield *passwordTextfield;
 @end
 
 @implementation JJViewController
@@ -22,7 +22,8 @@
     
     JJMaterialTextfield *userNameTextfield =[[JJMaterialTextfield alloc] initWithFrame:CGRectMake(40, 120, self.view.frame.size.width-80, 34)];
     userNameTextfield.textColor=[UIColor whiteColor];
-    [userNameTextfield enableMaterialPlaceHolder:YES];
+//    [userNameTextfield enableMaterialPlaceHolder:YES];
+    userNameTextfield.enableMaterialPlaceHolder = YES;
     userNameTextfield.errorColor=[UIColor colorWithRed:0.910 green:0.329 blue:0.271 alpha:1.000]; // FLAT RED COLOR
     userNameTextfield.lineColor=[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000];
     userNameTextfield.tintColor=[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000];
@@ -35,7 +36,8 @@
     JJMaterialTextfield *passTextField =[[JJMaterialTextfield alloc] initWithFrame:CGRectMake(40, 200, self.view.frame.size.width-80, 34)];
     passTextField.textColor=[UIColor whiteColor];
 
-    [passTextField enableMaterialPlaceHolder:YES];
+//    [passTextField enableMaterialPlaceHolder:YES];
+    passTextField.enableMaterialPlaceHolder = YES;
     
     passTextField.errorColor=[UIColor colorWithRed:0.910 green:0.329 blue:0.271 alpha:1.000]; // FLAT RED COLOR
     passTextField.lineColor=[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000];
@@ -50,14 +52,41 @@
     passTextField.placeholderAttributes = @{NSFontAttributeName : [UIFont systemFontOfSize:20],
                                             NSForegroundColorAttributeName : [[UIColor grayColor] colorWithAlphaComponent:.8]};
     [self.view addSubview:passTextField];
+    self.passwordTextfield = passTextField;
     
     UIButton *button=[[UIButton alloc] initWithFrame:CGRectMake(40, 300, self.view.frame.size.width-80, 60)];
     [button setTitle:@"Submit" forState:UIControlStateNormal];
     [button setBackgroundColor:[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000]];
     [self.view addSubview:button];
 
+    [button addTarget:self action:@selector(submit) forControlEvents:UIControlEventTouchUpInside];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    
+    [self updateUI];
+}
+
+- (void)updateUI
+{
+    self.passwordTextfield.text = nil; 
+}
+
+- (void)submit
+{
+//    UIViewController *vc = [[UIViewController alloc] init];
+//    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+//    vc.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(dismiss)];
+//    [self presentViewController:nav animated:YES completion:nil];
+    [self performSegueWithIdentifier:@"ShowNext" sender:self];
+}
+
+//- (void)dismiss
+//{
+//    [self dismissViewControllerAnimated:YES completion:nil];
+//}
 
 -(void)textFieldDidEndEditing:(JJMaterialTextfield *)textField{
     if (textField.text.length==0) {

--- a/Example/JJMaterialTextField/JJViewController.m
+++ b/Example/JJMaterialTextField/JJViewController.m
@@ -9,7 +9,7 @@
 #import "JJViewController.h"
 
 @interface JJViewController ()
-@property (nonatomic, strong) JJMaterialTextfield *passwordTextField;
+
 @end
 
 @implementation JJViewController
@@ -49,20 +49,13 @@
     passTextField.textColor = [UIColor whiteColor];
     passTextField.placeholderAttributes = @{NSFontAttributeName : [UIFont systemFontOfSize:20],
                                             NSForegroundColorAttributeName : [[UIColor grayColor] colorWithAlphaComponent:.8]};
-//    passTextField.placeholderFontSize = 20;
     [self.view addSubview:passTextField];
     
     UIButton *button=[[UIButton alloc] initWithFrame:CGRectMake(40, 300, self.view.frame.size.width-80, 60)];
     [button setTitle:@"Submit" forState:UIControlStateNormal];
     [button setBackgroundColor:[UIColor colorWithRed:0.482 green:0.800 blue:1.000 alpha:1.000]];
     [self.view addSubview:button];
-    [button addTarget:self action:@selector(submit) forControlEvents:UIControlEventTouchUpInside];
 
-}
-
-- (void)submit
-{
-    [self.passwordTextField showError];
 }
 
 

--- a/Example/JJMaterialTextField/Main.storyboard
+++ b/Example/JJMaterialTextField/Main.storyboard
@@ -59,6 +59,9 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="enableMaterialPlaceHolder" value="NO"/>
+                                </userDefinedRuntimeAttributes>
                             </textField>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/Example/JJMaterialTextField/Main.storyboard
+++ b/Example/JJMaterialTextField/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Eau-Uc-ybm">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -29,9 +30,65 @@
                             <constraint firstItem="9JP-7i-bz8" firstAttribute="leading" secondItem="TpU-gO-2f1" secondAttribute="leading" id="tPb-km-EjY"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="wsy-gC-wSs"/>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+                    <connections>
+                        <segue destination="uWg-1V-SUj" kind="show" identifier="ShowNext" id="cTG-Qo-BS8"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tc2-Qw-aMS" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="929" y="433"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="0XR-De-5Q8">
+            <objects>
+                <viewController id="uWg-1V-SUj" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="reo-2e-iXm"/>
+                        <viewControllerLayoutGuide type="bottom" id="coO-99-Qvg"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ELb-kz-Fz7">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="text here" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="49L-6e-bdA" customClass="JJMaterialTextfield">
+                                <rect key="frame" x="36" y="269" width="248" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="FbE-hd-Ig3"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="49L-6e-bdA" firstAttribute="centerY" secondItem="ELb-kz-Fz7" secondAttribute="centerY" id="OTd-GG-Aof"/>
+                            <constraint firstItem="49L-6e-bdA" firstAttribute="centerX" secondItem="ELb-kz-Fz7" secondAttribute="centerX" id="QQ7-Yk-ifH"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="49L-6e-bdA" secondAttribute="trailing" constant="20" id="cB6-Mu-LxC"/>
+                            <constraint firstItem="49L-6e-bdA" firstAttribute="leading" secondItem="ELb-kz-Fz7" secondAttribute="leadingMargin" constant="20" id="koa-fw-RYU"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ETd-Fl-D8s" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1462" y="433"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="7ZI-KI-SRS">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Eau-Uc-ybm" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="crO-Rz-Pmf">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="whP-gf-Uak" kind="relationship" relationship="rootViewController" id="F8r-gy-sTc"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1s5-NH-pkc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="305" y="433"/>
         </scene>

--- a/Pod/Classes/JJMaterialTextfield.h
+++ b/Pod/Classes/JJMaterialTextfield.h
@@ -10,6 +10,8 @@
 
 @interface JJMaterialTextfield : UITextField
 
+//@property (nonatomic, assign) CGFloat placeholderFontSize;
+@property (nonatomic, strong) NSDictionary *placeholderAttributes;
 @property (nonatomic,strong) UIColor *errorColor;
 @property (nonatomic,strong) UIColor *lineColor;
 

--- a/Pod/Classes/JJMaterialTextfield.h
+++ b/Pod/Classes/JJMaterialTextfield.h
@@ -16,6 +16,9 @@
 
 -(void)showError;
 -(void)hideError;
--(void)enableMaterialPlaceHolder:(BOOL)enable;
+//-(void)enableMaterialPlaceHolder:(BOOL)enable;
+
+@property (nonatomic) IBInspectable BOOL enableMaterialPlaceHolder;
+
 
 @end

--- a/Pod/Classes/JJMaterialTextfield.h
+++ b/Pod/Classes/JJMaterialTextfield.h
@@ -10,7 +10,6 @@
 
 @interface JJMaterialTextfield : UITextField
 
-//@property (nonatomic, assign) CGFloat placeholderFontSize;
 @property (nonatomic, strong) NSDictionary *placeholderAttributes;
 @property (nonatomic,strong) UIColor *errorColor;
 @property (nonatomic,strong) UIColor *lineColor;

--- a/Pod/Classes/JJMaterialTextfield.h
+++ b/Pod/Classes/JJMaterialTextfield.h
@@ -10,14 +10,36 @@
 
 @interface JJMaterialTextfield : UITextField
 
-@property (nonatomic, strong) NSDictionary *placeholderAttributes;
-@property (nonatomic,strong) UIColor *errorColor;
-@property (nonatomic,strong) UIColor *lineColor;
+/**
+ *  Attributes that are optionally applied to the placeholder text. Use this to style the placeholder differently than the regular text. Default is nil (meaning no additional styling will be applied to the placeholder. If nil, the placeholder will be styled the same as the textfield except its color will be a 0.8 alpha version of the textfield text color.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *placeholderAttributes;
 
--(void)showError;
--(void)hideError;
-//-(void)enableMaterialPlaceHolder:(BOOL)enable;
+/**
+ *  The color of the line when there is an error.
+ */
+@property (nonatomic, strong, nullable) UIColor *errorColor;
 
+/**
+ *  The color of the line when the textfield is active.  Default is [UIColor lightGrayColor];
+ */
+@property (nonatomic, strong, nullable) UIColor *lineColor;
+
+
+/**
+ *  Shows an error - makes the line the error color.
+ */
+- (void)showError;
+
+/**
+ *  Hides the error. Returns the line to normal.
+ */
+- (void)hideError;
+
+
+/**
+ *  Enables or disables the material placeholder (the placeholder jumping above the textfield on text entry). Default is YES.
+ */
 @property (nonatomic) IBInspectable BOOL enableMaterialPlaceHolder;
 
 

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -7,101 +7,114 @@
 //
 
 #import "JJMaterialTextfield.h"
+
 @interface JJMaterialTextfield (){
     UIView *line;
     UILabel *placeHolderLabel;
-    BOOL enablePlaceHolder;
     BOOL showError;
-
 }
+
 @end
 @implementation JJMaterialTextfield
 @synthesize errorColor,lineColor;
 
 #define DEFAULT_ALPHA_LINE 0.8
 
--(id)initWithFrame:(CGRect)frame{
-    
-    self=[super initWithFrame:frame];
+-(id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
     if (self) {
         [self commonInit];
     }
     return self;
 }
--(void)awakeFromNib{
-   
+
+-(void)awakeFromNib
+{
     [super awakeFromNib];
     [self commonInit];
     
 }
 
--(void)commonInit{
-    lineColor=[UIColor lightGrayColor];
-    errorColor=[UIColor colorWithRed:0.910 green:0.329 blue:0.271 alpha:1.000]; // FLAT RED COLOR
-    line=[[UIView alloc] init];
-    line.backgroundColor=[lineColor colorWithAlphaComponent:DEFAULT_ALPHA_LINE];
+-(void)commonInit
+{
+    lineColor = [UIColor lightGrayColor];
+    errorColor = [UIColor colorWithRed:0.910 green:0.329 blue:0.271 alpha:1.000]; // FLAT RED COLOR
+    line = [[UIView alloc] init];
+    line.backgroundColor = [lineColor colorWithAlphaComponent:DEFAULT_ALPHA_LINE];
     [self addSubview:line];
-    self.clipsToBounds=NO;
-    [self enableMaterialPlaceHolder:NO];
+    self.clipsToBounds = NO;
+    [self setEnableMaterialPlaceHolder:YES];
+//    [self enableMaterialPlaceHolder:NO];
+//    self.enableMaterialPlaceHolder = YES;
     [self addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     
 }
--(void)setText:(NSString *)text{
+
+-(void)setText:(NSString *)text
+{
     [super setText:text];
     [self textFieldDidChange:self];
-    
 }
--(IBAction)textFieldDidChange:(id)sender{
 
-    if (enablePlaceHolder) {
-        if (self.text.length>0) {
-            placeHolderLabel.alpha=1;
-        }else{
-            self.attributedPlaceholder=nil;
-        }
+-(IBAction)textFieldDidChange:(id)sender
+{
+    if (self.enableMaterialPlaceHolder) {
         
-        CGFloat duration=0.5;
-        CGFloat delay=0;
-        CGFloat damping=0.6;
-        CGFloat velocity=1;
+        if (!self.text || self.text.length > 0) {
+            placeHolderLabel.alpha = 1;
+            self.attributedPlaceholder = nil;
+        }
+//        else {
+//            self.attributedPlaceholder = nil;
+//        }
+        
+        CGFloat duration = 0.5;
+        CGFloat delay = 0;
+        CGFloat damping = 0.6;
+        CGFloat velocity = 1;
         
         [UIView animateWithDuration:duration
                               delay:delay
              usingSpringWithDamping:damping
               initialSpringVelocity:velocity
                             options:UIViewAnimationOptionCurveEaseInOut animations:^{
-                                //Animations
-                                //animacion
-                                if (self.text.length<=0) {
-                                    placeHolderLabel.transform=CGAffineTransformIdentity;
-                                }else{
-                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height - 5);
+
+                                if (!self.text || self.text.length <= 0) {
+                                    placeHolderLabel.transform = CGAffineTransformIdentity;
+                                }
+                                else {
+                                    placeHolderLabel.transform = CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height - 5);
                                 }
                                 
                             }
                          completion:^(BOOL finished) {
-                             //Completion Block
+                             
                          }];
-
        
     }
 }
 
--(IBAction)clearAction:(id)sender{
-    self.text=@"";
+-(IBAction)clearAction:(id)sender
+{
+    self.text = @"";
     [self textFieldDidChange:self];
 }
 
--(void)highlight{
+-(void)highlight
+{
     
     [UIView animateWithDuration: 0.3 // duración
                           delay: 0 // sin retardo antes de comenzar
                         options: UIViewAnimationOptionCurveEaseInOut //opciones
                      animations:^{
+                         
                          if (showError) {
                              line.backgroundColor=errorColor;
-                         }else
+                         }
+                         else {
                              line.backgroundColor=lineColor;
+                         }
                          
                      }
                      completion:^(BOOL finished) {
@@ -113,65 +126,85 @@
     
 }
 
--(void)unhighlight{
+-(void)unhighlight
+{
     [UIView animateWithDuration: 0.3 // duración
                           delay: 0 // sin retardo antes de comenzar
                         options: UIViewAnimationOptionCurveEaseInOut //opciones
                      animations:^{
+                         
                          if (showError) {
-                             line.backgroundColor=errorColor;
-                         }else
-                             line.backgroundColor=[lineColor colorWithAlphaComponent:DEFAULT_ALPHA_LINE];
+                             line.backgroundColor = errorColor;
+                         }
+                         else {
+                             line.backgroundColor = [lineColor colorWithAlphaComponent:DEFAULT_ALPHA_LINE];
+                         }
 
                          
                      }
                      completion:^(BOOL finished) {
                          if (finished) {
-                             
                              //finalizacion
                          }
                      }];
 
   }
 
-- (void)setPlaceholderAttributes:(NSDictionary *)placeholderAttributes {
+- (void)setPlaceholderAttributes:(NSDictionary *)placeholderAttributes
+{
     _placeholderAttributes = placeholderAttributes;
     [self setPlaceholder:self.placeholder];
 }
 
-
--(void)setPlaceholder:(NSString *)placeholder{
+-(void)setPlaceholder:(NSString *)placeholder
+{
     [super setPlaceholder:placeholder];
+    
     NSDictionary *atts = @{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.8],
                            NSFontAttributeName : [self.font fontWithSize: self.font.pointSize]};
     
-    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes: self.placeholderAttributes ?: atts];
+    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder ?: @"" attributes: self.placeholderAttributes ?: atts];
 
-    [self enableMaterialPlaceHolder:enablePlaceHolder];
+    [self setEnableMaterialPlaceHolder:self.enableMaterialPlaceHolder];
 }
 
--(void)enableMaterialPlaceHolder:(BOOL)enable{
+- (void)setEnableMaterialPlaceHolder:(BOOL)enableMaterialPlaceHolder
+{
+    _enableMaterialPlaceHolder = enableMaterialPlaceHolder;
+    
     if (!placeHolderLabel) {
-          placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
-         [self addSubview:placeHolderLabel];
+        placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
+        [self addSubview:placeHolderLabel];
     }
-    enablePlaceHolder=enable;
-    placeHolderLabel.alpha=0;
-    placeHolderLabel.attributedText=self.attributedPlaceholder;
+    placeHolderLabel.alpha = 0;
+    placeHolderLabel.attributedText = self.attributedPlaceholder;
     [placeHolderLabel sizeToFit];
-   
+    
 }
+
+//-(void)enableMaterialPlaceHolder:(BOOL)enable{
+//    if (!placeHolderLabel) {
+//          placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
+//         [self addSubview:placeHolderLabel];
+//    }
+//    enablePlaceHolder=enable;
+//    placeHolderLabel.alpha=0;
+//    placeHolderLabel.attributedText=self.attributedPlaceholder;
+//    [placeHolderLabel sizeToFit];
+//   
+//}
 
 - (BOOL)becomeFirstResponder
 {
     BOOL returnValue = [super becomeFirstResponder];
     
-        [self highlight];
+    [self highlight];
     
     return returnValue;
 }
 
--(BOOL)resignFirstResponder{
+-(BOOL)resignFirstResponder
+{
     BOOL returnValue = [super resignFirstResponder];
    
     [self unhighlight];

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -20,7 +20,7 @@
 
 #define DEFAULT_ALPHA_LINE 0.8
 
--(id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
@@ -29,14 +29,14 @@
     return self;
 }
 
--(void)awakeFromNib
+- (void)awakeFromNib
 {
     [super awakeFromNib];
     [self commonInit];
     
 }
 
--(void)commonInit
+- (void)commonInit
 {
     lineColor = [UIColor lightGrayColor];
     errorColor = [UIColor colorWithRed:0.910 green:0.329 blue:0.271 alpha:1.000]; // FLAT RED COLOR
@@ -51,13 +51,13 @@
     
 }
 
--(void)setText:(NSString *)text
+- (void)setText:(NSString *)text
 {
     [super setText:text];
     [self textFieldDidChange:self];
 }
 
--(IBAction)textFieldDidChange:(id)sender
+- (IBAction)textFieldDidChange:(id)sender
 {
     if (self.enableMaterialPlaceHolder) {
         

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -44,9 +44,7 @@
     line.backgroundColor = [lineColor colorWithAlphaComponent:DEFAULT_ALPHA_LINE];
     [self addSubview:line];
     self.clipsToBounds = NO;
-    [self setEnableMaterialPlaceHolder:YES];
-//    [self enableMaterialPlaceHolder:NO];
-//    self.enableMaterialPlaceHolder = YES;
+    [self setEnableMaterialPlaceHolder:self.enableMaterialPlaceHolder];
     [self addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     
 }

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -77,15 +77,16 @@
                                 if (self.text.length<=0) {
                                     placeHolderLabel.transform=CGAffineTransformIdentity;
                                 }else{
-                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height-3);
+//                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height-3);
+                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height);
                                 }
                             }
                          completion:^(BOOL finished) {
                              //Completion Block
                              
-                             if (self.text.length<=0) {
-                                 placeHolderLabel.alpha=0;
-                             }
+//                             if (self.text.length<=0) {
+//                                 placeHolderLabel.alpha=0;
+//                             }
                              self.attributedPlaceholder=_attString;
                          }];
 

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -143,7 +143,8 @@
 
 -(void)setPlaceholder:(NSString *)placeholder{
     [super setPlaceholder:placeholder];
-    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:@{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.5]}];
+    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:@{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.5],
+                                                                                                     NSFontAttributeName : [self.font fontWithSize:self.font.pointSize * 1.3]}];
     [self enableMaterialPlaceHolder:enablePlaceHolder];
     if (_attString.length==0) {
            _attString=self.attributedPlaceholder;

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -12,7 +12,7 @@
     UIView *line;
     UILabel *placeHolderLabel;
     BOOL enablePlaceHolder;
-    NSAttributedString *_attString;
+//    NSAttributedString *_attString;
     BOOL showError;
 
 }
@@ -77,9 +77,9 @@
                                 if (self.text.length<=0) {
                                     placeHolderLabel.transform=CGAffineTransformIdentity;
                                 }else{
-//                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height-3);
-                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height);
+                                    placeHolderLabel.transform=CGAffineTransformMakeTranslation(0, -placeHolderLabel.frame.size.height - 5);
                                 }
+                                
                             }
                          completion:^(BOOL finished) {
                              //Completion Block
@@ -87,7 +87,7 @@
 //                             if (self.text.length<=0) {
 //                                 placeHolderLabel.alpha=0;
 //                             }
-                             self.attributedPlaceholder=_attString;
+//                             self.attributedPlaceholder=_attString;
                          }];
 
        
@@ -141,14 +141,28 @@
 
   }
 
+- (void)setPlaceholderAttributes:(NSDictionary *)placeholderAttributes {
+    _placeholderAttributes = placeholderAttributes;
+    [self setPlaceholder:self.placeholder];
+}
+
+//-(void)setPlaceholderFontSize:(CGFloat)placeholderFontSize{
+//    _placeholderFontSize = placeholderFontSize;
+//    [self setPlaceholder:self.placeholder];
+//}
+
 -(void)setPlaceholder:(NSString *)placeholder{
     [super setPlaceholder:placeholder];
-    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:@{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.5],
-                                                                                                     NSFontAttributeName : [self.font fontWithSize:self.font.pointSize * 1.3]}];
+    NSDictionary *atts = @{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.8],
+                           NSFontAttributeName : [self.font fontWithSize: self.font.pointSize]};
+//                           NSFontAttributeName : [self.font fontWithSize: self.placeholderFontSize ?: self.font.pointSize]};
+                           
+    self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes: self.placeholderAttributes ?: atts];
+
     [self enableMaterialPlaceHolder:enablePlaceHolder];
-    if (_attString.length==0) {
-           _attString=self.attributedPlaceholder;
-    }
+//    if (_attString.length==0) {
+//           _attString=self.attributedPlaceholder;
+//    }
  
 }
 -(void)enableMaterialPlaceHolder:(BOOL)enable{

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -8,13 +8,14 @@
 
 #import "JJMaterialTextfield.h"
 
-@interface JJMaterialTextfield (){
+@interface JJMaterialTextfield ()
+{
     UIView *line;
     UILabel *placeHolderLabel;
     BOOL showError;
 }
-
 @end
+
 @implementation JJMaterialTextfield
 @synthesize errorColor,lineColor;
 
@@ -171,7 +172,7 @@
     _enableMaterialPlaceHolder = enableMaterialPlaceHolder;
     
     if (!placeHolderLabel) {
-        placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
+        placeHolderLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
         [self addSubview:placeHolderLabel];
     }
     placeHolderLabel.alpha = 0;
@@ -179,18 +180,6 @@
     [placeHolderLabel sizeToFit];
     
 }
-
-//-(void)enableMaterialPlaceHolder:(BOOL)enable{
-//    if (!placeHolderLabel) {
-//          placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];
-//         [self addSubview:placeHolderLabel];
-//    }
-//    enablePlaceHolder=enable;
-//    placeHolderLabel.alpha=0;
-//    placeHolderLabel.attributedText=self.attributedPlaceholder;
-//    [placeHolderLabel sizeToFit];
-//   
-//}
 
 - (BOOL)becomeFirstResponder
 {
@@ -201,7 +190,7 @@
     return returnValue;
 }
 
--(BOOL)resignFirstResponder
+- (BOOL)resignFirstResponder
 {
     BOOL returnValue = [super resignFirstResponder];
    
@@ -210,19 +199,22 @@
     return returnValue;
 }
 
--(void)showError{
-    showError=YES;
-    line.backgroundColor=errorColor;
+- (void)showError
+{
+    showError = YES;
+    line.backgroundColor = errorColor;
 }
 
--(void)hideError{
-    showError=NO;
-    line.backgroundColor=lineColor;
+- (void)hideError
+{
+    showError = NO;
+    line.backgroundColor = lineColor;
 }
 
--(void)layoutSubviews{
+- (void)layoutSubviews
+{
     [super layoutSubviews];
-    line.frame=CGRectMake(0, self.frame.size.height-1, self.frame.size.width, 1);
+    line.frame = CGRectMake(0, self.frame.size.height-1, self.frame.size.width, 1);
 }
 
 @end

--- a/Pod/Classes/JJMaterialTextfield.m
+++ b/Pod/Classes/JJMaterialTextfield.m
@@ -8,11 +8,9 @@
 
 #import "JJMaterialTextfield.h"
 @interface JJMaterialTextfield (){
-    
     UIView *line;
     UILabel *placeHolderLabel;
     BOOL enablePlaceHolder;
-//    NSAttributedString *_attString;
     BOOL showError;
 
 }
@@ -83,11 +81,6 @@
                             }
                          completion:^(BOOL finished) {
                              //Completion Block
-                             
-//                             if (self.text.length<=0) {
-//                                 placeHolderLabel.alpha=0;
-//                             }
-//                             self.attributedPlaceholder=_attString;
                          }];
 
        
@@ -146,25 +139,17 @@
     [self setPlaceholder:self.placeholder];
 }
 
-//-(void)setPlaceholderFontSize:(CGFloat)placeholderFontSize{
-//    _placeholderFontSize = placeholderFontSize;
-//    [self setPlaceholder:self.placeholder];
-//}
 
 -(void)setPlaceholder:(NSString *)placeholder{
     [super setPlaceholder:placeholder];
     NSDictionary *atts = @{NSForegroundColorAttributeName: [self.textColor colorWithAlphaComponent:0.8],
                            NSFontAttributeName : [self.font fontWithSize: self.font.pointSize]};
-//                           NSFontAttributeName : [self.font fontWithSize: self.placeholderFontSize ?: self.font.pointSize]};
-                           
+    
     self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes: self.placeholderAttributes ?: atts];
 
     [self enableMaterialPlaceHolder:enablePlaceHolder];
-//    if (_attString.length==0) {
-//           _attString=self.attributedPlaceholder;
-//    }
- 
 }
+
 -(void)enableMaterialPlaceHolder:(BOOL)enable{
     if (!placeHolderLabel) {
           placeHolderLabel=[[UILabel alloc] initWithFrame:CGRectMake(0, 6, 0, self.frame.size.height)];


### PR DESCRIPTION
This PR adds the ability to customize the attributed text attributes of the placeholder, as well as a few additional features described below.
-This is accomplished by adding an optional public NSDictionary property to the textfield that can contain style information and will be applied to the attributed text of the placeholder label. 
-If no optional NSDictionary is supplied, the textfield will style the placeholder label the same as the text of the label itself, but with .8 alpha version of the original text color.
-This PR raises the height of the placeholder slightly higher above the textfield in its upper position. 
-This PR also modifies the example to show how the textfield behaves when it is supplied with the optional styling dictionary and when it is not supplied with the optional styling dictionary. 
-This PR also makes the default behavior to enable the material placeholder, and adds the ability to enable/disable the material placeholder within interface builder.
